### PR TITLE
fix: support gnu-date (#4)

### DIFF
--- a/gh-user-stars
+++ b/gh-user-stars
@@ -27,7 +27,6 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-
 list_stars() {
   # shellcheck disable=SC2016
   gh api graphql --cache=5m --paginate -F first="${number}" -f query='
@@ -56,12 +55,22 @@ tableize() {
   column -t -s$'\t'
 }
 
+convert_date_for_utc_to_local(){
+  # Determine whether to use gnu-date or bsd-date
+  # If `date -help` fails, use bsd-date
+  if date --help 1>/dev/null 2>/dev/null; then
+    date -d "$1" +"%F %T"
+  else
+    date -r "$(date -u -jf %FT%TZ "$1" +%s)" +"%F %T"
+  fi
+}
+
 render() {
   local nameWithOwner starredAt
   all_stars="$(list_stars 2>/dev/null || true)"
   while read nameWithOwner starredAt
   do
-    local_starred_at=$(date -r "$(date -u -jf %FT%TZ "${starredAt}" +%s)" +"%F %T")
+    local_starred_at=$(convert_date_for_utc_to_local "${starredAt}")
     printf "%s\t%s\n" "$nameWithOwner" "$local_starred_at"
   done <<< "${all_stars}"
 }


### PR DESCRIPTION
fix #4 


### gnu-date
![スクリーンショット 2021-08-28 17 24 59](https://user-images.githubusercontent.com/20027695/131211592-6fb308eb-2119-4a8d-9a80-8d0bf284767b.png)

```
codespace ➜ /workspaces/gh-user-stars (support-gnu-date) $ uname -srv
Linux 5.4.0-1055-azure #57~18.04.1-Ubuntu SMP Fri Jul 16 19:40:19 UTC 2021
codespace ➜ /workspaces/gh-user-stars (support-gnu-date) $ lsb_release -d
Description:    Ubuntu 20.04.3 LTS
```

### bsd-date
<img width="654" alt="スクリーンショット 2021-08-28 17 26 07" src="https://user-images.githubusercontent.com/20027695/131211615-e10f25d0-36b4-4bed-9a07-a100a5dcc2d0.png">

```
❯ uname -srv                        
Darwin 20.4.0 Darwin Kernel Version 20.4.0: Fri Mar  5 01:14:14 PST 2021; root:xnu-7195.101.1~3/RELEASE_X86_64
```