### PR TITLE
Replace shebang for portability sake

### DIFF
--- a/gh-user-stars
+++ b/gh-user-stars
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 extensionPath="$(dirname "${0}")"
 source "${extensionPath}/libs.sh"

--- a/libs.sh
+++ b/libs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 list=""
 endCursor=""


### PR DESCRIPTION
The shebang used (#!/bin/bash)
has gretaer chance to fail (as it does on NixOS, for example).

https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability