### PR TITLE
Use local time

### DIFF
--- a/libs.sh
+++ b/libs.sh
@@ -29,7 +29,7 @@ call_star_api(){
 
 list_stars() {
   result=$(call_star_api "$1" "${endCursor}")
-  list="$(echo $result | jq -r '.data.viewer.starredRepositories.edges[] | [.node.nameWithOwner, (.starredAt|fromdateiso8601|gmtime|strflocaltime("%Y-%m-%dT%H:%M:%S%Z"))] | @tsv')"
+  list="$(echo $result | jq -r '.data.viewer.starredRepositories.edges[] | [.node.nameWithOwner, (.starredAt|fromdateiso8601|localtime|strflocaltime("%Y-%m-%d %H:%M:%S"))] | @tsv')"
   echo "${list}" | column -t -s$'\t'
   endCursor=$(echo $result | jq -r '.data.viewer.starredRepositories.pageInfo.endCursor')
   is_end=$(echo $result | jq -r '.data.viewer.starredRepositories.pageInfo.hasNextPage')


### PR DESCRIPTION
I'm not sure about the purpose of `|fromdateiso8601|gmtime|strflocaltime("%Y-%m-%d %H:%M:%S")` and the only thing it does on my machine is to show a confusing timezone without actually using it. Replacing `gmtime` with `localtime` seems to fix it.

Before:

<img width="540" alt="截屏2021-11-14 19 51 58" src="https://user-images.githubusercontent.com/44045911/141679843-128dce43-b33f-47e0-9295-c5bcc2f51845.png">

After:

<img width="520" alt="截屏2021-11-14 19 51 42" src="https://user-images.githubusercontent.com/44045911/141679838-4fff1874-6d81-4918-853b-c9a101b99770.png">
